### PR TITLE
port DataMapper's support of method callbacks to ardm

### DIFF
--- a/lib/ardm/ar/hooks.rb
+++ b/lib/ardm/ar/hooks.rb
@@ -1,9 +1,30 @@
 require 'active_support/concern'
+require 'active_support/core_ext/module/attribute_accessors'
 
 module Ardm
   module Ar
     module Hooks
       extend ActiveSupport::Concern
+
+      # For each class that defines custom hooks (i.e. not :save, :create, :destroy, etc),
+      # store the names of these custom hooks in an array
+      # as a class variable (@@methods_to_redefine) of that class.
+      #
+      # This is used to figure out which methods to redefine should they
+      # get defined after the callback method is defined.
+      # This allows us to wrap the original methods with `run_callbacks`.
+
+      included do
+        self.instance_eval do
+          def method_added(name)
+            if (self.class_variable_defined?(:@@methods_to_redefine) &&
+                self.methods_to_redefine && self.methods_to_redefine.include?(name))
+
+              self._redefine_original_method(name)
+            end
+          end
+        end
+      end
 
       module ClassMethods
         def before(event, meth=nil, &block)
@@ -19,11 +40,59 @@ module Ardm
             event = "validation"
           end
 
-          if meth.nil?
-            send "#{order}_#{event}", &block
-          else
-            send "#{order}_#{event}", meth
+          callback_name = "#{order}_#{event}".to_sym
+          if !ActiveRecord::Callbacks::CALLBACKS.include?(callback_name)
+            _define_callbacks_and_wrap_original_method(event.to_sym)
           end
+
+          if meth.nil?
+            send callback_name, &block
+          else
+            send callback_name, meth
+          end
+        end
+
+        def _redefine_original_method(name)
+          self.class_eval do
+            if method_defined?(name) && instance_method(name) != instance_method(_callbacks_method(name))
+              alias_method _original_method(name), name
+              alias_method name, _callbacks_method(name)
+            end
+          end
+        end
+
+        def _callbacks_method(name)
+          "_with_callbacks_#{name}".to_sym
+        end
+
+        def _original_method(name)
+          "_original_#{name}".to_sym
+        end
+
+        def _define_method_with_callbacks(name)
+          self.class_eval do
+            unless method_defined?(_callbacks_method(name))
+              define_method(_callbacks_method(name)) do |*args|
+                run_callbacks(name) do
+                  self.send(self.class._original_method(name), *args)
+                end
+              end
+            end
+          end
+        end
+
+        def _define_callbacks_and_wrap_original_method(name)
+          if !self.class_variable_defined?(:@@methods_to_redefine)
+            self.class_eval do
+              mattr_accessor :methods_to_redefine
+              self.methods_to_redefine = []
+            end
+          end
+          self.methods_to_redefine << name
+
+          self.class_eval { define_model_callbacks name }
+          _define_method_with_callbacks(name)
+          _redefine_original_method(name)
         end
       end
     end

--- a/spec/public/resource_spec.rb
+++ b/spec/public/resource_spec.rb
@@ -23,6 +23,45 @@ describe Ardm::Record do
     expect(@user).to respond_to(:raise_on_save_failure)
   end
 
+  describe "hooks" do
+    before do
+      @user_model.class_eval do
+        attr_accessor :custom_hook_call_count, :custom_method_call_count, :called_methods
+
+        before :custom_method do
+          @called_methods ||= []
+          @called_methods << "before_custom_method"
+          @custom_hook_call_count ||= 0
+          @custom_hook_call_count += 1
+        end
+
+        def custom_method
+          @called_methods ||= []
+          @called_methods << "custom_method"
+          @custom_method_call_count ||= 0
+          @custom_method_call_count += 1
+        end
+      end
+
+      @user = @user_model.new
+    end
+
+    it 'should call custom hook expected number of times' do
+      @user.custom_method
+      expect(@user.custom_hook_call_count).to eq(1)
+    end
+
+    it 'should call custom method expected number of times' do
+      @user.custom_method
+      expect(@user.custom_method_call_count).to eq(1)
+    end
+
+    it 'should call before_custom_method hook then call custom_method' do
+      @user.custom_method
+      expect(@user.called_methods).to eq(["before_custom_method", "custom_method"])
+    end
+  end
+
   describe '#raise_on_save_failure' do
     after do
       # reset to the default value


### PR DESCRIPTION
This commit ports DataMapper's support of method callbacks to `ardm` using ActiveRecord Callbacks.
This allows the [dm_observer gem](https://github.com/datamapper/dm-observer) to work.

I add support in the _ardm_hook for callbacks not defined in `ActiveRecord::Callbacks::CALLBACKS` such as `:before_create, :after_destroy, etc`.

I basically define custom model callbacks (using `define_model_callbacks`) if necessary and re-define the original methods with the `run_callbacks` wrapper method.

This commit addresses #4. 
